### PR TITLE
Fixed package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "identify-stream",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Indentify the contents of a Node stream based on the presence of a file signature.",
-  "main": "/lib/index.js",
+  "main": "./lib/index.js",
   "scripts": {
     "test": "nyc --reporter=text --reporter=text-summary mocha",
     "lint": "eslint ."


### PR DESCRIPTION
Fixed `main` entry in package.json causing the module to not be found throwing the below error:

```
internal/modules/cjs/loader.js:323
      throw err;
      ^

Error: Cannot find module 'S:\lib\index.js'. Please verify that the package.json has a valid "main" entry
    at tryPackage (internal/modules/cjs/loader.js:315:19)
    at Function.Module._load (internal/modules/cjs/loader.js:687:27)
    at require (internal/modules/cjs/helpers.js:74:18)
    at Module._compile (internal/modules/cjs/loader.js:1015:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1035:10)
    at Module.load (internal/modules/cjs/loader.js:879:32) {
  code: 'MODULE_NOT_FOUND',
  path: 'S:\\_Work\\[REDACTED]\\[REDACTED]\\node_modules\\identify-stream\\package.json',
  requestPath: 'identify-stream'
```